### PR TITLE
ci: re-enable trivy vulnerability scanning with SHA-pinned action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,12 +89,12 @@ jobs:
           interval: 10
           retries: 8
 
-#       - name: Upload Trivy report as artifact
-#         uses: actions/upload-artifact@v4
-#         with:
-#           name: trivy-report
-#           path: /tmp/trivy-report-*.json
-# 
+      - name: Upload Trivy report as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-report
+          path: /tmp/trivy-report-*.json
+
       - name: Push image
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
Re-enable Trivy scanning by reverting the changes from PR #22. Pin trivy-action to `ed142fd0673e97e23eac54620cfb913e5ce36c25` (v0.36.0) for security.

Co-authored-by: Poojan Savani <poojan@hasura.io>